### PR TITLE
rvm#buffer_path_identifier Fix

### DIFF
--- a/plugin/rvm.vim
+++ b/plugin/rvm.vim
@@ -39,7 +39,9 @@ function! rvm#buffer_path_identifier(...)
   else
     let path = fnamemodify(name, ':h')
   endif
-  return system('rvm tools path-identifier '.s:shellesc(path))
+
+  let path_identifier = system('rvm tools path-identifier '.s:shellesc(path))
+  return split(path_identifier)[-1]
 endfunction
 
 function! s:Rvm(bang,...) abort


### PR DESCRIPTION
In case we were in a deep nested file, the rvm tools path-identifier api returned both the path along with the ruby version information, I have corrected the same by spliting the return string and the returning the last item in the list which is the ruby version information.
