### PR TITLE
:Rvm with a buffer of a non-existent file generates error.

### DIFF
--- a/plugin/rvm.vim
+++ b/plugin/rvm.vim
@@ -36,6 +36,8 @@ function! rvm#buffer_path_identifier(...)
     let path = '.'
   elseif isdirectory(name)
     let path = name
+  elseif !isdirectory(resolve(fnamemodify(name, ":p:h")))
+    let path = '.'
   else
     let path = fnamemodify(name, ':h')
   endif


### PR DESCRIPTION
CtrlpMRUFiles opens also non-existent files, but rvm (the cmd line tootl) doesn't like this. I've put a check to avoid this.

I've in my .vimrc

``` vim
augroup rvm
  autocmd!
  autocmd BufEnter * Rvm
augroup END
```
